### PR TITLE
Bug Fix: Reduce expiration date

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read(*names, **kwargs):
 
 setup(
     name='octokitpy',
-    version='0.9.1',
+    version='0.9.2',
     license='MIT license',
     description='Python client for GitHub API',
     long_description='%s\n%s' % (

--- a/src/octokit/__init__.py
+++ b/src/octokit/__init__.py
@@ -134,7 +134,7 @@ class Base(object):
     def _app_auth_get_jwt(self, app_id, key):
         payload = {
             'iat': int(datetime.datetime.timestamp(datetime.datetime.now())),
-            'exp': int(datetime.datetime.timestamp(datetime.datetime.now())) + (10 * 60),
+            'exp': int(datetime.datetime.timestamp(datetime.datetime.now())) + (9 * 60),
             'iss': app_id,
         }
         return jwt.encode(payload, key, algorithm='RS256')


### PR DESCRIPTION
The difference between `now()` and `now() + 10*60` is greater than ten
minutes. GitHub's API now cares about that.