### PR TITLE
fix: for newer version so of octokitpy-routes '*' is included in the webhook data published

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read(*names, **kwargs):
 
 setup(
     name="octokitpy",
-    version="0.14.2",
+    version="0.14.3",
     license="MIT license",
     description="Python client for GitHub API",
     long_description="%s\n%s"

--- a/src/octokit/webhook.py
+++ b/src/octokit/webhook.py
@@ -21,7 +21,7 @@ def valid_guid(guid):
 
 
 def valid_event(event, events):
-    return event in webhook_names or "*" in webhook_names
+    return event in webhook_names
 
 
 def valid_user_agent(ua):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -116,3 +116,14 @@ class TestWebhook(object):
         payload = ""
         secret = "secret"
         assert webhook.verify(headers, payload, secret, events=["*"], return_app_id=True)
+
+    def test_must_have_a_valid_event(self):
+        headers = {
+            "X-Hub-Signature": "sha1=25af6174a0fcecc4d346680a72b7ce644b9a88e8",
+            "X-GitHub-Event": "blah",
+            "X-GitHub-Delivery": "72d3162f-cc78-11e3-81ab-4c9367dc0958",
+        }
+        payload = ""
+        secret = "secret"
+        events = ["push"]
+        assert webhook.verify(headers, payload, secret, events=events) is False


### PR DESCRIPTION
fixes #108